### PR TITLE
Use ASIO compatible boost::asio::error instead of errc

### DIFF
--- a/azmq/detail/actor_service.hpp
+++ b/azmq/detail/actor_service.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/asio/signal_set.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/container/flat_map.hpp>
 
 #include <string>
@@ -195,7 +196,7 @@ namespace detail {
                                                  boost::system::error_code & ec) {
                 switch (opt.name()) {
                 case is_alive::static_name::value :
-                    ec = make_error_code(boost::system::errc::no_protocol_option);
+                    ec = make_error_code(boost::asio::error::no_protocol_option);
                     break;
                 case detached::static_name::value :
                     {
@@ -212,10 +213,10 @@ namespace detail {
                     }
                     break;
                 case last_error::static_name::value :
-                    ec = make_error_code(boost::system::errc::no_protocol_option);
+                    ec = make_error_code(boost::asio::error::no_protocol_option);
                     break;
                 default:
-                    ec = make_error_code(boost::system::errc::not_supported);
+                    ec = make_error_code(boost::asio::error::not_supported);
                     break;
                 }
                 return ec;
@@ -238,7 +239,7 @@ namespace detail {
                     }
                     break;
                 case start::static_name::value :
-                    ec = make_error_code(boost::system::errc::no_protocol_option);
+                    ec = make_error_code(boost::asio::error::no_protocol_option);
                     break;
                 case last_error::static_name::value :
                     {
@@ -247,7 +248,7 @@ namespace detail {
                     }
                     break;
                 default:
-                    ec = make_error_code(boost::system::errc::not_supported);
+                        ec = make_error_code(boost::asio::error::not_supported);
                     break;
                 }
                 return ec;

--- a/azmq/detail/actor_service.hpp
+++ b/azmq/detail/actor_service.hpp
@@ -216,7 +216,7 @@ namespace detail {
                     ec = make_error_code(boost::asio::error::no_protocol_option);
                     break;
                 default:
-                    ec = make_error_code(boost::asio::error::not_supported);
+                    ec = make_error_code(boost::asio::error::operation_not_supported);
                     break;
                 }
                 return ec;
@@ -248,7 +248,7 @@ namespace detail {
                     }
                     break;
                 default:
-                        ec = make_error_code(boost::asio::error::not_supported);
+                        ec = make_error_code(boost::asio::error::operation_not_supported);
                     break;
                 }
                 return ec;

--- a/azmq/detail/reactor_op.hpp
+++ b/azmq/detail/reactor_op.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/asio/io_service.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/intrusive/list.hpp>
 
 namespace azmq {
@@ -32,7 +33,7 @@ public:
     }
 
     static boost::system::error_code canceled() {
-        static boost::system::error_code ec = make_error_code(boost::system::errc::operation_canceled);
+        static boost::system::error_code ec = make_error_code(boost::asio::error::operation_aborted);
         return ec;
     }
 
@@ -44,10 +45,10 @@ protected:
     complete_func_type complete_func_;
 
     bool try_again() const {
-        return ec_.value() == boost::system::errc::resource_unavailable_try_again;
+        return ec_.value() == boost::asio::error::try_again;
     }
 
-    bool is_canceled() const { return ec_.value() == boost::system::errc::operation_canceled; }
+    bool is_canceled() const { return ec_.value() == boost::asio::error::operation_aborted; }
 
     reactor_op(perform_func_type perform_func,
                complete_func_type complete_func)

--- a/azmq/detail/receive_op.hpp
+++ b/azmq/detail/receive_op.hpp
@@ -45,7 +45,7 @@ public:
 
 protected:
     bool more() const {
-        return ec_ == boost::system::errc::no_buffer_space && bytes_transferred_;
+        return ec_ == boost::asio::error::no_buffer_space && bytes_transferred_;
     }
 
 private:

--- a/azmq/detail/socket_ops.hpp
+++ b/azmq/detail/socket_ops.hpp
@@ -19,6 +19,7 @@
 #include <boost/regex.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <boost/asio/io_service.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/asio/socket_base.hpp>
 #if ! defined BOOST_ASIO_WINDOWS
     #include <boost/asio/posix/stream_descriptor.hpp>
@@ -304,7 +305,7 @@ namespace detail {
                     return 0;
 
                 if (msg.buffer_copy(*it++) < sz) {
-                    ec = make_error_code(boost::system::errc::no_buffer_space);
+                    ec = make_error_code(boost::asio::error::no_buffer_space);
                     return 0;
                 }
 
@@ -313,7 +314,7 @@ namespace detail {
             } while ((it != std::end(buffers)) && msg.more());
 
             if (msg.more())
-                ec = make_error_code(boost::system::errc::no_buffer_space);
+                ec = make_error_code(boost::asio::error::no_buffer_space);
             return res;
         }
 


### PR DESCRIPTION
Fix for https://github.com/zeromq/azmq/issues/75. Also replaced all `errc` error codes with ASIO equivalents.