### PR TITLE
make message_vector satisfy ConstBufferSequence for direct use in send()

### DIFF
--- a/azmq/message.hpp
+++ b/azmq/message.hpp
@@ -106,6 +106,10 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
             return boost::asio::buffer(pv, size());
         }
 
+        operator boost::asio::const_buffer() const {
+            return cbuffer();
+        }
+
         boost::asio::const_buffer buffer() const {
             auto pv = zmq_msg_data(const_cast<zmq_msg_t*>(&msg_));
             return boost::asio::buffer(pv, size());


### PR DESCRIPTION
This implicit cast from azmq::message to boost::asio::const_buffer makes azmq::message_vector satisfy ConstBufferSequence, so it can be used directly in a send() call to send a multipart message.