### PR TITLE
Set CMAKE_MODULE_PATH relative to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(USE_LIBCXX)
     set(ADDITIONAL_LIBS "pthread")
 endif()
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/config")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config")
 
 find_package(Boost 1.54 COMPONENTS system log date_time thread chrono regex random REQUIRED)
 find_package(ZeroMQ 4.0 REQUIRED)


### PR DESCRIPTION
When azmq is build as a child project using `add_directory` command in parent `CMakeLists.txt` then child `CMakeLists.txt` in `azmq` folder sets `CMAKE_MODULE_PATH` relative to the folder where parent `CMakeLists.txt` resides. As a result discovery of ZeroMQ libraries fails.
Using `CMAKE_CURRENT_SOURCE_DIR` to set `CMAKE_MODULE_PATH` removes that problem.