### PR TITLE
Add missing CMAKE_THREAD_LIBS_INIT to tests

### DIFF
--- a/test/signal/CMakeLists.txt
+++ b/test/signal/CMakeLists.txt
@@ -3,6 +3,7 @@ project(test_signal)
 add_executable(${PROJECT_NAME} main.cpp)
 
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES}
-                                      ${ZeroMQ_LIBRARIES})
+                                      ${ZeroMQ_LIBRARIES}
+                                      ${CMAKE_THREAD_LIBS_INIT})
 
 add_catch_test(${PROJECT_NAME})

--- a/test/socket_ops/CMakeLists.txt
+++ b/test/socket_ops/CMakeLists.txt
@@ -3,6 +3,7 @@ project(test_socket_ops)
 add_executable(${PROJECT_NAME} main.cpp)
 
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES}
-                                      ${ZeroMQ_LIBRARIES})
+                                      ${ZeroMQ_LIBRARIES}
+                                      ${CMAKE_THREAD_LIBS_INIT})
 
 add_catch_test(${PROJECT_NAME})


### PR DESCRIPTION
When building azmq under buildroot, signal and socket_ops tests run into
a similar linker error as the socket test did in issue #118. Simply
adding CMAKE_THREAD_LIBS_INIT to the linked libraries for those tests
resolves the issue.

Resolves issue #130 