### PR TITLE
Pull request for #138 Boost 1.48 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config")
 
-find_package(Boost 1.54 COMPONENTS system log date_time thread chrono regex random REQUIRED)
+find_package(Boost 1.48 COMPONENTS system date_time thread chrono regex random REQUIRED)
 find_package(ZeroMQ 4.0 REQUIRED)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
@@ -49,7 +49,9 @@ include_directories(${Boost_INCLUDE_DIRS}
                     ${ZeroMQ_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR})
 
-enable_testing()
+if(NOT AZMQ_NO_TESTS)
+    enable_testing()
+endif()
 
 macro(add_catch_test name)
     if (TEST_REPORT_FORMAT)
@@ -59,8 +61,10 @@ macro(add_catch_test name)
     endif()
 endmacro()
 
-add_subdirectory(test)
-add_subdirectory(doc)
+if(NOT AZMQ_NO_TESTS)
+    add_subdirectory(test)
+    add_subdirectory(doc)
+endif()
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/azmq
         DESTINATION include)

--- a/README.md
+++ b/README.md
@@ -21,14 +21,19 @@ which supports C++11. Currently this has been tested with -
 * Xcode 6 on OS X 10.9
 * Xcode 6.4 on OS X 10.10
 * Xcode 7.1 on OS X 10.11
+* GCC 4.8 + Boost 1.48 on CentOS 6
+* GCC 4.8 + Boost 1.53 on CentOS 7
 * GCC 4.8 on Arch Linux and Ubuntu
-* GCC 4.9 on Ubuntu
+* GCC 4.8 on Ubuntu
 * GCC 5.3 + Boost 1.60 on Ubuntu
 * Microsoft Visual Studio 2013 on Windows Server 2008 R2
 
 Library dependencies are -
-* Boost 1.54 or later
+* Boost 1.48 or later
 * ZeroMQ 4.0.x
+
+Tests and example code require -
+* Boost 1.54 or later
 
 To build on Linux / OS X -
 ```

--- a/azmq/detail/context_ops.hpp
+++ b/azmq/detail/context_ops.hpp
@@ -15,7 +15,7 @@
 #include <boost/assert.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <zmq.h>
 
@@ -36,7 +36,7 @@ namespace detail {
         }
 
         static context_type get_context(bool create_new = false) {
-            static lock_type::mutex_type mtx;
+            static boost::mutex mtx;
             static std::weak_ptr<void> ctx;
 
             if (create_new) return ctx_new();
@@ -74,4 +74,3 @@ namespace detail {
 } // namespace azmq
 
 #endif // AZMQ_DETAIL_CONTEXT_OPS_HPP__
-

--- a/azmq/detail/socket_ops.hpp
+++ b/azmq/detail/socket_ops.hpp
@@ -17,7 +17,6 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
-#include <boost/utility/string_ref.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/socket_base.hpp>
 #if ! defined BOOST_ASIO_WINDOWS

--- a/azmq/detail/socket_service.hpp
+++ b/azmq/detail/socket_service.hpp
@@ -30,7 +30,6 @@
 #include <boost/system/system_error.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/thread/lock_guard.hpp>
 
 #include <memory>
 #include <typeindex>

--- a/azmq/error.hpp
+++ b/azmq/error.hpp
@@ -11,8 +11,21 @@
 #include "detail/config.hpp"
 
 #include <boost/system/error_code.hpp>
+#include <boost/version.hpp>
 #include <zmq.h>
 #include <string>
+
+
+#if BOOST_VERSION < 105400
+    #ifndef BOOST_NOEXCEPT
+        #ifdef BOOST_NO_CXX11_NOEXCEPT
+            #define BOOST_NOEXCEPT
+        #else
+            #define BOOST_NOEXCEPT noexcept
+        #endif
+    #endif
+    #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
+#endif
 
 namespace azmq {
 AZMQ_V1_INLINE_NAMESPACE_BEGIN

--- a/azmq/message.hpp
+++ b/azmq/message.hpp
@@ -13,7 +13,10 @@
 #include "util/scope_guard.hpp"
 
 #include <boost/assert.hpp>
-#include <boost/utility/string_ref.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105300
+    #include <boost/utility/string_ref.hpp>
+#endif
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/buffers_iterator.hpp>
 #include <boost/system/system_error.hpp>
@@ -129,9 +132,11 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
                 throw boost::system::system_error(make_error_code());
         }
 
+#if BOOST_VERSION >= 105300
         explicit message(boost::string_ref str)
             : message(boost::asio::buffer(str.data(), str.size()))
         { }
+#endif
 
         message(message && rhs) BOOST_NOEXCEPT
             : msg_(rhs.msg_)


### PR DESCRIPTION
Modifying mutex reference
Conditional define for BOOST_SYSTEM_NOEXCEPT
Conditional drop of string_ref reference
Option to disable tests which aren't adopted for older boost
Removed Boost log component reference in find_package
Decreased Boost version requirement in find_package.