### PR TITLE
Fixed comparison for BOOST_VERSION

### DIFF
--- a/azmq/detail/actor_service.hpp
+++ b/azmq/detail/actor_service.hpp
@@ -24,7 +24,7 @@
 #include <boost/asio/signal_set.hpp>
 #include <boost/container/flat_map.hpp>
 
-#if BOOST_VERSION < 10700
+#if BOOST_VERSION < 107000
 #   define AZMQ_DETAIL_USE_IO_SERVICE 1
 #endif
 

--- a/azmq/detail/socket_service.hpp
+++ b/azmq/detail/socket_service.hpp
@@ -32,7 +32,7 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/thread/mutex.hpp>
 
-#if BOOST_VERSION < 10700
+#if BOOST_VERSION < 107000
 #   define AZMQ_DETAIL_USE_IO_SERVICE 1
 #else
 #   include <boost/asio/post.hpp>


### PR DESCRIPTION
This fixes #153 
Macro BOOST_VERSION consists of 6 digits (https://www.boost.org/doc/libs/1_70_0/boost/version.hpp)