### PR TITLE
Fix dangling reference to buffer object for async_send() operations

### DIFF
--- a/azmq/detail/send_op.hpp
+++ b/azmq/detail/send_op.hpp
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    ConstBufferSequence const& buffers_;
+    ConstBufferSequence buffers_;
     flags_type flags_;
 };
 


### PR DESCRIPTION
The `send_buffer_op_base` object only saved a reference to the `boost::asio::const_buffer` object given to `async_send()`. This required callers to ensure the same life-time for the boost::asio::const_buffer as for the underlying memory it refers to, which seems like an unnecessarily strict requirement.

Normally with boost::asio, the caller only has to ensure the proper life-time of the underlying memory, not the buffer object itself. `receive_buffer_op_base` already saves a copy, so it seems better for `send_buffer_op_base` to do the same.

This fixes #145.