### PR TITLE
Update to support ZeroMQ 4.3.2 and Boost 1.72.0

### DIFF
--- a/AzmqCPack.cmake
+++ b/AzmqCPack.cmake
@@ -8,8 +8,8 @@ in general, and Asio in particular.
 
 The main abstraction exposed by the library is azmq::socket which
 provides an Asio style socket interface to the underlying zeromq socket
-and interfaces with Asio's io_service().  The socket implementation
-participates in the io_service's reactor for asynchronous IO and
+and interfaces with Asio's io_context().  The socket implementation
+participates in the io_context's reactor for asynchronous IO and
 may be freely mixed with other Asio socket types (raw TCP/UDP/Serial/etc.).")
 set(CPACK_PACKAGE_VERSION               "1.1.0")
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ in general, and Asio in particular.
 
 The main abstraction exposed by the library is azmq::socket which
 provides an Asio style socket interface to the underlying zeromq socket
-and interfaces with Asio's io_service().  The socket implementation
-participates in the io_service's reactor for asynchronous IO and
+and interfaces with Asio's io_context().  The socket implementation
+participates in the io_context's reactor for asynchronous IO and
 may be freely mixed with other Asio socket types (raw TCP/UDP/Serial/etc.).
 
 ## Building and installation
@@ -82,7 +82,7 @@ http://zeromq.org/intro:read-the-manual
 namespace asio = boost::asio;
 
 int main(int argc, char** argv) {
-    asio::io_service ios;
+    asio::io_context ios;
     azmq::sub_socket subscriber(ios);
     subscriber.connect("tcp://192.168.55.112:5556");
     subscriber.connect("tcp://192.168.55.201:7721");

--- a/azmq/context.hpp
+++ b/azmq/context.hpp
@@ -13,7 +13,7 @@
 #include "option.hpp"
 #include "error.hpp"
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <zmq.h>
 
 namespace azmq {
@@ -28,10 +28,10 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
      *  \remark Must be called before any sockets are created
      */
     template<typename Option>
-    boost::system::error_code set_option(boost::asio::io_service & io_service,
+    boost::system::error_code set_option(boost::asio::io_context & ctxt,
                                          const Option & option,
                                          boost::system::error_code & ec) {
-        return boost::asio::use_service<detail::socket_service>(io_service).set_option(option, ec);
+        return boost::asio::use_service<detail::socket_service>(ctxt).set_option(option, ec);
     }
 
     /** \brief set options on the zeromq context.
@@ -40,9 +40,9 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
      *  \remark Must be called before any sockets are created
      */
     template<typename Option>
-    void set_option(boost::asio::io_service & io_service, const Option & option) {
+    void set_option(boost::asio::io_context & ctxt, const Option & option) {
         boost::system::error_code ec;
-        if (set_option(io_service, option, ec))
+        if (set_option(ctxt, option, ec))
             throw boost::system::system_error(ec);
     }
 
@@ -52,10 +52,10 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
      *  \param ec boost::system::error_code
      */
     template<typename Option>
-    boost::system::error_code get_option(boost::asio::io_service & io_service,
+    boost::system::error_code get_option(boost::asio::io_context & ctxt,
                                          Option & option,
                                          boost::system::error_code & ec) {
-        return boost::asio::use_service<detail::socket_service>(io_service).get_option(option, ec);
+        return boost::asio::use_service<detail::socket_service>(ctxt).get_option(option, ec);
     }
 
     /** \brief get option from zeromq context
@@ -64,9 +64,9 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
      *  \param ec boost::system::error_code
      */
     template<typename Option>
-    void get_option(boost::asio::io_service & io_service, Option & option) {
+    void get_option(boost::asio::io_context & ctxt, Option & option) {
         boost::system::error_code ec;
-        if (get_option(io_service, option))
+        if (get_option(ctxt, option))
             throw boost::system::system_error(ec);
     }
 AZMQ_V1_INLINE_NAMESPACE_END

--- a/azmq/detail/basic_io_object.hpp
+++ b/azmq/detail/basic_io_object.hpp
@@ -9,7 +9,7 @@
 #ifndef AZMQ_DETAIL_BASIC_IO_OBJECT_HPP__
 #define AZMQ_DETAIL_BASIC_IO_OBJECT_HPP__
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/basic_io_object.hpp>
 
 namespace azmq {
@@ -41,8 +41,8 @@ namespace detail {
         friend class core_access<Service>;
 
     public:
-        basic_io_object(boost::asio::io_service& ios)
-            : boost::asio::basic_io_object<Service>(ios)
+        basic_io_object(boost::asio::io_context& ctxt)
+            : boost::asio::basic_io_object<Service>(ctxt)
         { }
     };
 } // namespace detail

--- a/azmq/detail/reactor_op.hpp
+++ b/azmq/detail/reactor_op.hpp
@@ -13,7 +13,7 @@
 #include "socket_ops.hpp"
 
 #include <boost/optional.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/intrusive/list.hpp>
 
 namespace azmq {

--- a/azmq/detail/receive_op.hpp
+++ b/azmq/detail/receive_op.hpp
@@ -14,7 +14,7 @@
 #include "socket_ops.hpp"
 #include "reactor_op.hpp"
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include <zmq.h>
 

--- a/azmq/detail/send_op.hpp
+++ b/azmq/detail/send_op.hpp
@@ -13,7 +13,7 @@
 #include "socket_ops.hpp"
 #include "reactor_op.hpp"
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include <zmq.h>
 #include <iterator>

--- a/azmq/detail/service_base.hpp
+++ b/azmq/detail/service_base.hpp
@@ -9,24 +9,24 @@
 #ifndef AZMQ_DETAIL_SERVICE_BASE_HPP_
 #define AZMQ_DETAIL_SERVICE_BASE_HPP_
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 namespace azmq {
 namespace detail {
     template <typename T>
     class service_id
-        : public boost::asio::io_service::id
+        : public boost::asio::io_context::id
     { };
 
     template<typename T>
     class service_base
-        : public boost::asio::io_service::service {
+        : public boost::asio::io_context::service {
     public :
         static azmq::detail::service_id<T> id;
 
         // Constructor.
-        service_base(boost::asio::io_service& io_service)
-            : boost::asio::io_service::service(io_service)
+        service_base(boost::asio::io_context &ctxt)
+            : boost::asio::io_context::service(ctxt)
         { }
     };
 

--- a/azmq/detail/socket_ext.hpp
+++ b/azmq/detail/socket_ext.hpp
@@ -11,7 +11,7 @@
 #include "../error.hpp"
 
 #include <boost/assert.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include <memory>
 #include <typeindex>
@@ -35,9 +35,9 @@ namespace detail {
             return *this;
         }
 
-        void on_install(boost::asio::io_service& ios, void * socket) const {
+        void on_install(boost::asio::io_context& ctxt, void * socket) const {
             BOOST_ASSERT_MSG(ptr_, "reusing moved instance of socket_ext");
-            ptr_->on_install(ios, socket);
+            ptr_->on_install(ctxt, socket);
         }
 
         void on_remove() {
@@ -83,7 +83,7 @@ namespace detail {
         struct concept {
             virtual ~concept() = default;
 
-            virtual void on_install(boost::asio::io_service &, void *) = 0;
+            virtual void on_install(boost::asio::io_context&, void *) = 0;
             virtual void on_remove() = 0;
             virtual boost::system::error_code set_option(opt_concept const&, boost::system::error_code &) = 0;
             virtual boost::system::error_code get_option(opt_concept &, boost::system::error_code &) = 0;
@@ -96,7 +96,7 @@ namespace detail {
 
             model(T data): data_(std::move(data)) { }
 
-            void on_install(boost::asio::io_service & ios, void * socket) override { data_.on_install(ios, socket); }
+            void on_install(boost::asio::io_context& ctxt, void * socket) override { data_.on_install(ctxt, socket); }
             void on_remove() override { data_.on_remove(); }
             boost::system::error_code set_option(opt_concept const& opt, boost::system::error_code & ec) override {
                 return data_.set_option(opt, ec);

--- a/azmq/socket.hpp
+++ b/azmq/socket.hpp
@@ -18,7 +18,7 @@
 #include "detail/receive_op.hpp"
 
 #include <boost/asio/basic_io_object.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/system/error_code.hpp>
 
@@ -87,21 +87,21 @@ public:
     using conflate = opt::boolean<ZMQ_CONFLATE>;
 
     /** \brief socket constructor
-     *  \param ios reference to an asio::io_service
+     *  \param ios reference to an asio::io_context
      *  \param s_type int socket type
      *      For socket types see the zeromq documentation
      *  \param optimize_single_threaded bool
      *      Defaults to false - socket is not optimized for a single
-     *      threaded io_service
+     *      threaded io_context
      *  \remarks
      *      ZeroMQ's socket types are not thread safe. Because there is no
-     *      guarantee that the supplied io_service is running in a single
+     *      guarantee that the supplied io_context is running in a single
      *      thread, Aziomq by default wraps all calls to ZeroMQ APIs with
      *      a mutex. If you can guarantee that a single thread has called
-     *      io_service.run() you may bypass the mutex by passing true for
+     *      io_context.run() you may bypass the mutex by passing true for
      *      optimize_single_threaded.
      */
-    explicit socket(boost::asio::io_service& ios,
+    explicit socket(boost::asio::io_context& ios,
                     int type,
                     bool optimize_single_threaded = false)
             : azmq::detail::basic_io_object<detail::socket_service>(ios) {
@@ -111,7 +111,7 @@ public:
     }
 
     socket(socket&& other)
-        : azmq::detail::basic_io_object<detail::socket_service>(other.get_io_service()) {
+        : azmq::detail::basic_io_object<detail::socket_service>(other.get_executor().context()) {
         get_service().move_construct(get_implementation(),
                                      other.get_service(),
                                      other.get_implementation());
@@ -644,12 +644,12 @@ public:
     }
 
     /** \brief monitor events on a socket
-        *  \param ios io_service on which to bind the returned monitor socket
+        *  \param ios io_context on which to bind the returned monitor socket
         *  \param events int mask of events to publish to returned socket
         *  \param ec error_code to set on error
         *  \returns socket
     **/
-    socket monitor(boost::asio::io_service & ios,
+    socket monitor(boost::asio::io_context & ios,
                    int events,
                    boost::system::error_code & ec) {
         auto uri = get_service().monitor(get_implementation(), events, ec);
@@ -663,11 +663,11 @@ public:
     }
 
     /** \brief monitor events on a socket
-        *  \param ios io_service on which to bind the returned monitor socket
+        *  \param ios io_context on which to bind the returned monitor socket
         *  \param events int mask of events to publish to returned socket
         *  \returns socket
     **/
-    socket monitor(boost::asio::io_service & ios,
+    socket monitor(boost::asio::io_context & ios,
                    int events) {
         boost::system::error_code ec;
         auto res = monitor(ios, events, ec);
@@ -691,7 +691,7 @@ namespace detail {
         typedef socket Base;
 
     public:
-        specialized_socket(boost::asio::io_service & ios,
+        specialized_socket(boost::asio::io_context & ios,
                            bool optimize_single_threaded = false)
             : Base(ios, Type, optimize_single_threaded)
         {

--- a/doc/examples/actor/main.cpp
+++ b/doc/examples/actor/main.cpp
@@ -1,7 +1,7 @@
 #include <azmq/actor.hpp>
 
 #include <boost/utility/string_ref.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/deadline_timer.hpp>
@@ -17,7 +17,7 @@ namespace pt = boost::posix_time;
 
 class server_t {
 public:
-    server_t(asio::io_service & ios)
+    server_t(asio::io_context& ios)
         : pimpl_(std::make_shared<impl>())
         , frontend_(azmq::actor::spawn(ios, run, pimpl_))
     { }
@@ -38,7 +38,7 @@ public:
     }
 
 private:
-    // for such a simple example, this is overkill, but is a useful pattern for 
+    // for such a simple example, this is overkill, but is a useful pattern for
     // real servers that need to maintain state
     struct impl {
         std::atomic<unsigned long> pings_;
@@ -76,7 +76,7 @@ private:
     // This is the function run by the background thread
     static void run(azmq::socket & backend, ptr pimpl) {
         do_receive(backend, pimpl);
-        backend.get_io_service().run();
+        backend.get_executor().context().run();
     }
 
     azmq::socket frontend_;
@@ -97,7 +97,7 @@ void schedule_ping(asio::deadline_timer & timer, server_t & server) {
 };
 
 int main(int argc, char** argv) {
-    asio::io_service ios;
+    asio::io_context ios;
 
     std::cout << "Running...";
     std::cout.flush();

--- a/test/actor/main.cpp
+++ b/test/actor/main.cpp
@@ -42,14 +42,14 @@ TEST_CASE( "Async Send/Receive", "[actor]" ) {
             boost::asio::buffer(b)
         }};
 
-        boost::asio::io_service ios;
+        boost::asio::io_context ios;
         auto s = azmq::actor::spawn(ios, [&](azmq::socket & ss) {
             ss.async_receive(rcv_bufs, [&](boost::system::error_code const& ec, size_t bytes_transferred) {
                 ecb = ec;
                 btb = bytes_transferred;
                 ios.stop();
             });
-            ss.get_io_service().run();
+            ss.get_executor().context().run();
         });
 
         s.async_send(snd_bufs, [&] (boost::system::error_code const& ec, size_t bytes_transferred) {
@@ -57,7 +57,7 @@ TEST_CASE( "Async Send/Receive", "[actor]" ) {
             btc = bytes_transferred;
         });
 
-        boost::asio::io_service::work w(ios);
+        boost::asio::io_context::work w(ios);
         ios.run();
     }
 

--- a/test/signal/main.cpp
+++ b/test/signal/main.cpp
@@ -8,13 +8,13 @@
 */
 #include <azmq/signal.hpp>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #define CATCH_CONFIG_MAIN
 #include "../catch.hpp"
 
 TEST_CASE( "Send/Receive a signal", "[signal]" ) {
-    boost::asio::io_service ios;
+    boost::asio::io_context ios;
     azmq::pair_socket sb(ios);
     azmq::pair_socket sc(ios);
 


### PR DESCRIPTION
The `socket` test case was failing due to an additional event added in new version of ZeroMQ. `ZMQ_EVENT_HANDSHAKE_SUCCEEDED` event is emitted after the connection is established on both sides. **However**, the older ZeroMQ version may lose support because of this change. So a change to README.md will be necessary.

All reference to `io_service` is replaced to `io_context`.

The compiling was failing due to the removed `get_io_service()` / `get_io_context()` functions. Now we should replace all calls to `get_executor().context()`.