### PR TITLE
socket ops: use taus88 instead of mersenne_twister

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Individual Contributors
 =======================
 Thomas W Rodgers <rodgert@twrodgers.com>
 Andrey Upadyshev <oliora@gmail.com>
+Tim Blechmann <tim@klingt.org>

--- a/azmq/detail/socket_ops.hpp
+++ b/azmq/detail/socket_ops.hpp
@@ -25,7 +25,7 @@
     #include <boost/asio/ip/tcp.hpp>
 #endif
 #include <boost/system/error_code.hpp>
-#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/taus88.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 #include <boost/range/metafunctions.hpp>
 
@@ -141,7 +141,7 @@ namespace detail {
                                              : boost::lexical_cast<uint16_t>(last_str);
                 uint16_t port = first;
                 if (opcode[0] == '!') {
-                    static boost::random::mt19937 gen;
+                    static boost::random::taus88 gen;
                     boost::random::uniform_int_distribution<> port_range(port, last);
                     port = port_range(gen);
                 }


### PR DESCRIPTION
mt19937 is a great rng, but it requires a rather large state. taus88 is
a very decent rng with a much smaller memory footprint