### PR TITLE
azmq: replace boost.regex with std

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config")
 
-find_package(Boost 1.48 COMPONENTS system date_time thread chrono regex random REQUIRED)
+find_package(Boost 1.48 COMPONENTS system date_time thread chrono random REQUIRED)
 find_package(ZeroMQ 4.0 REQUIRED)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)

--- a/azmq/detail/socket_ops.hpp
+++ b/azmq/detail/socket_ops.hpp
@@ -16,7 +16,6 @@
 #include <boost/assert.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/regex.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/socket_base.hpp>
 #if ! defined BOOST_ASIO_WINDOWS
@@ -34,6 +33,7 @@
 #include <cerrno>
 #include <iterator>
 #include <memory>
+#include <regex>
 #include <string>
 #include <sstream>
 #include <type_traits>
@@ -123,14 +123,14 @@ namespace detail {
                                               endpoint_type & ep,
                                               boost::system::error_code & ec) {
             BOOST_ASSERT_MSG(socket, "invalid socket");
-            const boost::regex simple_tcp("^tcp://.*:(\\d+)$");
-            const boost::regex dynamic_tcp("^(tcp://.*):([*!])(\\[(\\d+)?-(\\d+)?\\])?$");
-            boost::smatch mres;
+            static const std::regex simple_tcp("^tcp://.*:(\\d+)$");
+            static const std::regex dynamic_tcp("^(tcp://.*):([*!])(\\[(\\d+)?-(\\d+)?\\])?$");
+            std::smatch mres;
             int rc = -1;
-            if (boost::regex_match(ep, mres, simple_tcp)) {
+            if (std::regex_match(ep, mres, simple_tcp)) {
                 if (zmq_bind(socket.get(), ep.c_str()) == 0)
                     rc = boost::lexical_cast<uint16_t>(mres.str(1));
-            } else if (boost::regex_match(ep, mres, dynamic_tcp)) {
+            } else if (std::regex_match(ep, mres, dynamic_tcp)) {
                 auto const& hostname = mres.str(1);
                 auto const& opcode = mres.str(2);
                 auto const& first_str = mres.str(4);


### PR DESCRIPTION
we can reduce the dependencies onto a boost.regex library by using
std::regex and friends.

furthermore we can cache the compiled regex instead of building it
every time