### PR TITLE
socket_ops: silence signed/unsigned comparison warning

### DIFF
--- a/azmq/detail/socket_ops.hpp
+++ b/azmq/detail/socket_ops.hpp
@@ -273,7 +273,7 @@ namespace detail {
         {
             size_t res = 0;
             auto last = std::distance(std::begin(buffers), std::end(buffers)) - 1;
-            auto index = 0u;
+            decltype(last) index = 0u;
             for (auto it = std::begin(buffers); it != std::end(buffers); ++it, ++index) {
                 auto f = index == last ? flags
                                        : flags | ZMQ_SNDMORE;


### PR DESCRIPTION
`last` is a signed type, while `0u` is an unsigned type, but we
obviously want to have `index` and `last` to be of the same type (well,
we typically don't care too much, but compilers can be quite naggy about
signed/unsigned comparisons)