### PR TITLE
context_ops: fix bug handling zmq_ctx_set result

### DIFF
--- a/azmq/detail/context_ops.hpp
+++ b/azmq/detail/context_ops.hpp
@@ -53,7 +53,7 @@ namespace detail {
                                                     boost::system::error_code & ec) {
             BOOST_ASSERT_MSG(ctx, "context must not be null");
             auto rc = zmq_ctx_set(ctx.get(), option.name(), option.value());
-            if (!rc)
+            if (rc < 0)
                 ec = make_error_code();
             return ec;
         }

--- a/test/context_ops/main.cpp
+++ b/test/context_ops/main.cpp
@@ -39,3 +39,12 @@ TEST_CASE( "context_options", "[context]" ) {
     REQUIRE(!ec);
     REQUIRE(res.value() == 2);
 }
+
+TEST_CASE( "invalid option", "[context]" ) {
+  auto ctx = azmq::detail::context_ops::get_context();
+  using io_threads = azmq::detail::context_ops::io_threads;
+  boost::system::error_code ec;
+  azmq::detail::context_ops::set_option(ctx, io_threads(-1), ec);
+  REQUIRE(ec);
+  REQUIRE(ec.value() == EINVAL);
+}


### PR DESCRIPTION
This looks like a typo

The zmq_ctx_set() function returns zero if successful. Otherwise it returns -1 and sets errno ...
http://api.zeromq.org/4-0:zmq-ctx-set