### PR TITLE
azmq/detail/context_ops.hpp: Assign ZMQ_MAX_SOCKETS to max_sockets

### DIFF
--- a/azmq/detail/context_ops.hpp
+++ b/azmq/detail/context_ops.hpp
@@ -28,7 +28,7 @@ namespace detail {
         using lock_type = boost::lock_guard<boost::mutex>;
 
         using io_threads = opt::integer<ZMQ_IO_THREADS>;
-        using max_sockets = opt::integer<ZMQ_MAXMSGSIZE>;
+        using max_sockets = opt::integer<ZMQ_MAX_SOCKETS>;
         using ipv6 = opt::boolean<ZMQ_IPV6>;
 
         static context_type ctx_new() {


### PR DESCRIPTION
Without this patch, max_sockets references ZMQ_MAXMSGSIZE which
isn't quite right ;) Probably a typo - lets just quickly fix it!

I've tested this locally by subscribing to >1000 topics to avoid
the proverbial "Too many open files" and already ensuring that
my 'ulimit -n <>' soft & hard limits allow for the extra sockets.