### PR TITLE
Only use Catch2 version 2.x

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,8 @@
-find_package(Catch2)
-if ( NOT Catch2 )
+find_package(Catch2 2.13.7 QUIET)
+if(TARGET Catch2::Catch2)
+    message(STATUS "Using system installed Catch2 v${Catch2_VERSION}" )
+else()
+    message(STATUS "Fetching Catch2 from github")
     Include(FetchContent)
     FetchContent_Declare(
             Catch2


### PR DESCRIPTION
Catch2 version 3.x introduces API breaking changes and is currently in
development. If we find something other than a 2.x version ignore it and
fetch the latest 2.x version from github