### PR TITLE
Fix nullification of message const& in socket::send()

### DIFF
--- a/azmq/detail/socket_ops.hpp
+++ b/azmq/detail/socket_ops.hpp
@@ -251,12 +251,12 @@ namespace detail {
             return false;
         }
 
-        static size_t send(message const& msg,
+        static size_t send(message msg,
                            socket_type & socket,
                            flags_type flags,
                            boost::system::error_code & ec) {
             BOOST_ASSERT_MSG(socket, "Invalid socket");
-            auto rc = zmq_msg_send(const_cast<zmq_msg_t*>(&msg.msg_), socket.get(), flags);
+            auto rc = zmq_msg_send(&msg.msg_, socket.get(), flags);
             if (rc < 0) {
                 ec = make_error_code();
                 return 0;
@@ -288,7 +288,7 @@ namespace detail {
                               flags_type flags,
                               boost::system::error_code & ec) {
             BOOST_ASSERT_MSG(socket, "Invalid socket");
-            auto rc = zmq_msg_recv(const_cast<zmq_msg_t*>(&msg.msg_), socket.get(), flags);
+            auto rc = zmq_msg_recv(&msg.msg_, socket.get(), flags);
             if (rc < 0) {
                 ec = make_error_code();
                 return 0;

--- a/azmq/message.hpp
+++ b/azmq/message.hpp
@@ -154,16 +154,16 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
         }
 
         message(message const& rhs) {
-            auto rc = zmq_msg_init(const_cast<zmq_msg_t*>(&msg_));
+            auto rc = zmq_msg_init(&msg_);
             BOOST_ASSERT_MSG(rc == 0, "zmq_msg_init return non-zero");
-            rc = zmq_msg_copy(const_cast<zmq_msg_t*>(&msg_),
+            rc = zmq_msg_copy(&msg_,
                               const_cast<zmq_msg_t*>(&rhs.msg_));
             if (rc)
                 throw boost::system::system_error(make_error_code());
         }
 
         message& operator=(message const& rhs) {
-            auto rc = zmq_msg_copy(const_cast<zmq_msg_t*>(&msg_),
+            auto rc = zmq_msg_copy(&msg_,
                                    const_cast<zmq_msg_t*>(&rhs.msg_));
             if (rc)
                 throw boost::system::system_error(make_error_code());
@@ -283,7 +283,7 @@ AZMQ_V1_INLINE_NAMESPACE_BEGIN
             if (rc)
                 throw boost::system::system_error(make_error_code());
 
-            auto pdst = zmq_msg_data(const_cast<zmq_msg_t*>(&msg_));
+            auto pdst = zmq_msg_data(&msg_);
             auto psrc = zmq_msg_data(&tmp);
             ::memcpy(pdst, psrc, sz);
         }

--- a/azmq/socket.hpp
+++ b/azmq/socket.hpp
@@ -23,6 +23,7 @@
 #include <boost/system/error_code.hpp>
 
 #include <type_traits>
+#include <utility>
 
 namespace azmq {
 AZMQ_V1_INLINE_NAMESPACE_BEGIN
@@ -447,10 +448,10 @@ public:
      *  \param flags specifying how the send call is to be made
      *  \param ec set to indicate what, if any, error occurred
      */
-    std::size_t send(message const& msg,
+    std::size_t send(message msg,
                      flags_type flags,
                      boost::system::error_code & ec) {
-        return get_service().send(get_implementation(), msg, flags, ec);
+        return get_service().send(get_implementation(), std::move(msg), flags, ec);
     }
 
     /** \brief Send some data from the socket
@@ -458,10 +459,10 @@ public:
      *  \param flags specifying how the send call is to be made
      *  \return bytes transferred
      */
-    std::size_t send(message const& msg,
+    std::size_t send(message msg,
                      flags_type flags = 0) {
         boost::system::error_code ec;
-        auto res = get_service().send(get_implementation(), msg, flags, ec);
+        auto res = get_service().send(get_implementation(), std::move(msg), flags, ec);
         if (ec)
             throw boost::system::system_error(ec);
         return res;

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -615,7 +615,7 @@ TEST_CASE( "Socket Monitor", "[socket]" ) {
     t.join();
 
     {
-        int i = 0;
+        size_t i = 0;
         CHECK(client_monitor.events_.at(i++).e == ZMQ_EVENT_CONNECT_DELAYED);
         CHECK(client_monitor.events_.at(i++).e == ZMQ_EVENT_CONNECTED);
         #ifdef ZMQ_EVENT_HANDSHAKE_SUCCEEDED
@@ -626,7 +626,7 @@ TEST_CASE( "Socket Monitor", "[socket]" ) {
   }
 
   {
-      int i = 0;
+      size_t i = 0;
       CHECK(server_monitor.events_.at(i++).e == ZMQ_EVENT_LISTENING);
       CHECK(server_monitor.events_.at(i++).e == ZMQ_EVENT_ACCEPTED);
       #ifdef ZMQ_EVENT_HANDSHAKE_SUCCEEDED


### PR DESCRIPTION
I hope the commit message explains the problem well enough.
The test-case I added fails without the accompanying change to the library, since the message was left emptied (or "nullified" as the zmq docs put it) after `sc.send(snd_msg)` before.

c.f. http://api.zeromq.org/4-0:zmq-msg-send
> The zmq_msg_t structure passed to zmq_msg_send() is nullified during the call. If you want to send the same message to multiple sockets you have to copy it using (e.g. using zmq_msg_copy()).