### PR TITLE
Notify the completion handler through the handler's associated executor

### DIFF
--- a/azmq/detail/receive_op.hpp
+++ b/azmq/detail/receive_op.hpp
@@ -14,11 +14,14 @@
 #include "socket_ops.hpp"
 #include "reactor_op.hpp"
 
+#include <boost/version.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/executor_work_guard.hpp>
+#if BOOST_VERSION >= 107900
 #include <boost/asio/recycling_allocator.hpp>
 #include <boost/asio/bind_allocator.hpp>
+#endif
 
 #include <zmq.h>
 
@@ -65,11 +68,21 @@ public:
         { }
 
     virtual void do_complete() override {
+#if BOOST_VERSION >= 107900
         auto alloc = boost::asio::get_associated_allocator(
             handler_, boost::asio::recycling_allocator<void>());
-        boost::asio::dispatch(work_guard.get_executor(), boost::asio::bind_allocator(alloc, [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_]() mutable {
+#endif
+        boost::asio::dispatch(work_guard.get_executor(),
+#if BOOST_VERSION >= 107900
+            boost::asio::bind_allocator(alloc,
+#endif
+                [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_]() mutable {
             handler_(ec_, bytes_transferred_);
-        }));
+        })
+#if BOOST_VERSION >= 107900
+        )
+#endif
+            ;
     }
 
 private:
@@ -90,11 +103,21 @@ public:
         { }
 
     virtual void do_complete() override {
+#if BOOST_VERSION >= 107900
         auto alloc = boost::asio::get_associated_allocator(
             handler_, boost::asio::recycling_allocator<void>());
-        boost::asio::dispatch(work_guard.get_executor(), boost::asio::bind_allocator(alloc, [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_, more = this->more()]() mutable {
+#endif
+        boost::asio::dispatch(work_guard.get_executor(),
+#if BOOST_VERSION >= 107900
+            boost::asio::bind_allocator(alloc,
+#endif
+                [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_, more = this->more()]() mutable {
             handler_(ec_, std::make_pair(bytes_transferred_, more));
-        }));
+        })
+#if BOOST_VERSION >= 107900
+        )
+#endif
+            ;
     }
 
 private:
@@ -132,11 +155,21 @@ public:
         { }
 
     virtual void do_complete() override {
+#if BOOST_VERSION >= 107900
         auto alloc = boost::asio::get_associated_allocator(
             handler_, boost::asio::recycling_allocator<void>());
-        boost::asio::dispatch(work_guard.get_executor(), boost::asio::bind_allocator(alloc, [ec_ = this->ec_, handler_ = std::move(handler_), msg_= std::move(msg_), bytes_transferred_ = this->bytes_transferred_]() mutable {
+#endif
+        boost::asio::dispatch(work_guard.get_executor(),
+#if BOOST_VERSION >= 107900
+            boost::asio::bind_allocator(alloc,
+#endif
+                [ec_ = this->ec_, handler_ = std::move(handler_), msg_ = std::move(msg_), bytes_transferred_ = this->bytes_transferred_]() mutable {
             handler_(ec_, msg_, bytes_transferred_);
-        }));
+        })
+#if BOOST_VERSION >= 107900
+        )
+#endif
+            ;
     }
 
 private:

--- a/azmq/detail/receive_op.hpp
+++ b/azmq/detail/receive_op.hpp
@@ -32,7 +32,7 @@ namespace detail {
 template<typename MutableBufferSequence>
 class receive_buffer_op_base : public reactor_op {
 public:
-    receive_buffer_op_base(MutableBufferSequence const& buffers, flags_type flags)
+    receive_buffer_op_base(MutableBufferSequence& buffers, flags_type flags)
         : buffers_(buffers)
         , flags_(flags)
         { }
@@ -51,7 +51,7 @@ protected:
     }
 
 private:
-    MutableBufferSequence buffers_;
+    MutableBufferSequence& buffers_;
     flags_type flags_;
 };
 
@@ -59,7 +59,7 @@ template<typename MutableBufferSequence,
          typename Handler>
 class receive_buffer_op : public receive_buffer_op_base<MutableBufferSequence> {
 public:
-    receive_buffer_op(MutableBufferSequence const& buffers,
+    receive_buffer_op(MutableBufferSequence& buffers,
                       Handler handler,
                       socket_ops::flags_type flags)
         : receive_buffer_op_base<MutableBufferSequence>(buffers, flags)
@@ -94,7 +94,7 @@ template<typename MutableBufferSequence,
          typename Handler>
 class receive_more_buffer_op : public receive_buffer_op_base<MutableBufferSequence> {
 public:
-    receive_more_buffer_op(MutableBufferSequence const& buffers,
+    receive_more_buffer_op(MutableBufferSequence& buffers,
                            Handler handler,
                            socket_ops::flags_type flags)
         : receive_buffer_op_base<MutableBufferSequence>(buffers, flags)

--- a/azmq/detail/receive_op.hpp
+++ b/azmq/detail/receive_op.hpp
@@ -69,7 +69,7 @@ protected:
     }
 
 private:
-    typename std::conditional<std::is_same_v<MutableBufferSequence, azmq::message>, MutableBufferSequence const&, MutableBufferSequence>::type buffers_;
+    typename std::conditional<std::is_same<MutableBufferSequence, azmq::message>::value, MutableBufferSequence const&, MutableBufferSequence>::type buffers_;
     flags_type flags_;
 };
 

--- a/azmq/detail/receive_op.hpp
+++ b/azmq/detail/receive_op.hpp
@@ -32,7 +32,7 @@ namespace detail {
 template<typename MutableBufferSequence>
 class receive_buffer_op_base : public reactor_op {
 public:
-    receive_buffer_op_base(MutableBufferSequence& buffers, flags_type flags)
+    receive_buffer_op_base(MutableBufferSequence const& buffers, flags_type flags)
         : buffers_(buffers)
         , flags_(flags)
         { }
@@ -51,7 +51,7 @@ protected:
     }
 
 private:
-    MutableBufferSequence& buffers_;
+    MutableBufferSequence buffers_;
     flags_type flags_;
 };
 
@@ -59,7 +59,7 @@ template<typename MutableBufferSequence,
          typename Handler>
 class receive_buffer_op : public receive_buffer_op_base<MutableBufferSequence> {
 public:
-    receive_buffer_op(MutableBufferSequence& buffers,
+    receive_buffer_op(MutableBufferSequence const& buffers,
                       Handler handler,
                       socket_ops::flags_type flags)
         : receive_buffer_op_base<MutableBufferSequence>(buffers, flags)
@@ -94,7 +94,7 @@ template<typename MutableBufferSequence,
          typename Handler>
 class receive_more_buffer_op : public receive_buffer_op_base<MutableBufferSequence> {
 public:
-    receive_more_buffer_op(MutableBufferSequence& buffers,
+    receive_more_buffer_op(MutableBufferSequence const& buffers,
                            Handler handler,
                            socket_ops::flags_type flags)
         : receive_buffer_op_base<MutableBufferSequence>(buffers, flags)

--- a/azmq/detail/send_op.hpp
+++ b/azmq/detail/send_op.hpp
@@ -13,11 +13,14 @@
 #include "socket_ops.hpp"
 #include "reactor_op.hpp"
 
+#include <boost/version.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/executor_work_guard.hpp>
+#if BOOST_VERSION >= 107900
 #include <boost/asio/recycling_allocator.hpp>
 #include <boost/asio/bind_allocator.hpp>
+#endif
 
 #include <zmq.h>
 #include <iterator>
@@ -60,11 +63,21 @@ public:
     { }
 
     virtual void do_complete() override {
+#if BOOST_VERSION >= 107900
         auto alloc = boost::asio::get_associated_allocator(
             handler_, boost::asio::recycling_allocator<void>());
-        boost::asio::dispatch(work_guard.get_executor(), boost::asio::bind_allocator(alloc, [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_]() mutable {
+#endif
+        boost::asio::dispatch(work_guard.get_executor(),
+#if BOOST_VERSION >= 107900
+            boost::asio::bind_allocator(alloc,
+#endif
+                [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_]() mutable {
             handler_(ec_, bytes_transferred_);
-        }));
+        })
+#if BOOST_VERSION >= 107900
+        )
+#endif
+            ;
     }
 
 private:
@@ -104,11 +117,22 @@ public:
     { }
 
     virtual void do_complete() override {
+#if BOOST_VERSION >= 107900
         auto alloc = boost::asio::get_associated_allocator(
-            handler_, boost::asio::recycling_allocator<void>());
-        boost::asio::dispatch(work_guard.get_executor(), boost::asio::bind_allocator(alloc, [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_]() mutable {
+                handler_, boost::asio::recycling_allocator<void>());
+#endif
+        boost::asio::dispatch(work_guard.get_executor(),
+#if BOOST_VERSION >= 107900
+            boost::asio::bind_allocator(alloc,
+#endif
+                [ec_ = this->ec_, handler_ = std::move(handler_), bytes_transferred_ = this->bytes_transferred_]() mutable {
             handler_(ec_, bytes_transferred_);
-        }));
+        })
+#if BOOST_VERSION >= 107900
+        )
+#endif
+        ;
+
     }
 
 private:

--- a/azmq/socket.hpp
+++ b/azmq/socket.hpp
@@ -510,7 +510,7 @@ public:
      */
     template<typename MutableBufferSequence,
              typename ReadHandler>
-    void async_receive(MutableBufferSequence const& buffers,
+    void async_receive(MutableBufferSequence& buffers,
                        ReadHandler && handler,
                        flags_type flags = 0) {
         using type = detail::receive_buffer_op<MutableBufferSequence, ReadHandler>;
@@ -539,7 +539,7 @@ public:
      */
     template<typename MutableBufferSequence,
              typename ReadMoreHandler>
-    void async_receive_more(MutableBufferSequence const& buffers,
+    void async_receive_more(MutableBufferSequence& buffers,
                             ReadMoreHandler && handler,
                             flags_type flags = 0) {
         using type = detail::receive_more_buffer_op<MutableBufferSequence, ReadMoreHandler>;
@@ -712,7 +712,7 @@ struct async_send_initiation {
 template<typename MutableBufferSequence>
 struct async_receive_initiation {
   azmq::socket &socket;
-  MutableBufferSequence const &buffers;
+  MutableBufferSequence &buffers;
 
   template<typename CompletionHandler>
   void operator()(CompletionHandler &&completion_handler) {
@@ -726,7 +726,7 @@ struct async_receive_initiation {
 template<typename MutableBufferSequence>
 struct async_receive_more_initiation {
   azmq::socket &socket;
-  MutableBufferSequence const &buffers;
+  MutableBufferSequence &buffers;
 
   template<typename CompletionHandler>
   void operator()(CompletionHandler &&completion_handler) {
@@ -748,7 +748,7 @@ auto async_send(azmq::socket &socket, ConstBufferSequence const &buffers,
 }
 
 template<class CompletionToken, class MutableBufferSequence>
-auto async_receive(azmq::socket &socket, MutableBufferSequence const &buffers,
+auto async_receive(azmq::socket &socket, MutableBufferSequence &buffers,
                    CompletionToken &&token)
 -> BOOST_ASIO_INITFN_RESULT_TYPE(CompletionToken,
                                  void(boost::system::error_code, size_t)) {

--- a/azmq/socket.hpp
+++ b/azmq/socket.hpp
@@ -761,7 +761,7 @@ template<class CompletionToken, class MutableBufferSequence>
 auto async_receive_more(azmq::socket &socket, MutableBufferSequence &buffers,
                         CompletionToken &&token)
 -> BOOST_ASIO_INITFN_RESULT_TYPE(CompletionToken,
-                                 void(boost::system::error_code, size_t)) {
+                                 void(boost::system::error_code, azmq::socket::more_result_type)) {
 
     return boost::asio::async_initiate<CompletionToken, void(boost::system::error_code, size_t)>(
         async_receive_more_initiation<MutableBufferSequence>{socket, buffers}, token);

--- a/azmq/socket.hpp
+++ b/azmq/socket.hpp
@@ -761,7 +761,7 @@ template<class CompletionToken, class MutableBufferSequence>
 auto async_receive_more(azmq::socket &socket, MutableBufferSequence &buffers,
                         CompletionToken &&token)
 -> BOOST_ASIO_INITFN_RESULT_TYPE(CompletionToken,
-                                 void(boost::system::error_code, azmq::socket::more_result_type)) {
+                                 void(boost::system::error_code, size_t)) {
 
     return boost::asio::async_initiate<CompletionToken, void(boost::system::error_code, size_t)>(
         async_receive_more_initiation<MutableBufferSequence>{socket, buffers}, token);

--- a/azmq/socket.hpp
+++ b/azmq/socket.hpp
@@ -510,7 +510,7 @@ public:
      */
     template<typename MutableBufferSequence,
              typename ReadHandler>
-    void async_receive(MutableBufferSequence& buffers,
+    void async_receive(MutableBufferSequence const& buffers,
                        ReadHandler && handler,
                        flags_type flags = 0) {
         using type = detail::receive_buffer_op<MutableBufferSequence, ReadHandler>;
@@ -539,7 +539,7 @@ public:
      */
     template<typename MutableBufferSequence,
              typename ReadMoreHandler>
-    void async_receive_more(MutableBufferSequence& buffers,
+    void async_receive_more(MutableBufferSequence const& buffers,
                             ReadMoreHandler && handler,
                             flags_type flags = 0) {
         using type = detail::receive_more_buffer_op<MutableBufferSequence, ReadMoreHandler>;
@@ -712,7 +712,7 @@ struct async_send_initiation {
 template<typename MutableBufferSequence>
 struct async_receive_initiation {
   azmq::socket &socket;
-  MutableBufferSequence &buffers;
+  MutableBufferSequence const &buffers;
 
   template<typename CompletionHandler>
   void operator()(CompletionHandler &&completion_handler) {
@@ -726,7 +726,7 @@ struct async_receive_initiation {
 template<typename MutableBufferSequence>
 struct async_receive_more_initiation {
   azmq::socket &socket;
-  MutableBufferSequence &buffers;
+  MutableBufferSequence const &buffers;
 
   template<typename CompletionHandler>
   void operator()(CompletionHandler &&completion_handler) {
@@ -748,7 +748,7 @@ auto async_send(azmq::socket &socket, ConstBufferSequence const &buffers,
 }
 
 template<class CompletionToken, class MutableBufferSequence>
-auto async_receive(azmq::socket &socket, MutableBufferSequence &buffers,
+auto async_receive(azmq::socket &socket, MutableBufferSequence const &buffers,
                    CompletionToken &&token)
 -> BOOST_ASIO_INITFN_RESULT_TYPE(CompletionToken,
                                  void(boost::system::error_code, size_t)) {

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -9,6 +9,7 @@
 #include <azmq/socket.hpp>
 #include <azmq/util/scope_guard.hpp>
 
+#include <boost/current_function.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -899,7 +899,7 @@ TEST_CASE("Async Operation Send/Receive single message, stackful coroutine, one 
 
 TEST_CASE("Async Operation Send/Receive single message, check thread safety", "[socket_ops]") {
 	boost::asio::io_service ios;
-#if BOOST_VERSION > 107400
+#if BOOST_VERSION >= 107400
 	boost::asio::strand<boost::asio::any_io_executor> strand{ios.get_executor()};
 #else
 	boost::asio::strand<boost::asio::executor> strand{ios.get_executor()};

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -910,10 +910,10 @@ TEST_CASE("Async Operation Send/Receive single message, check thread safety", "[
 
 	//send coroutine task
 	boost::asio::spawn(strand, [&](boost::asio::yield_context yield) {
-		ASSERT_TRUE(strand.running_in_this_thread());
+		REQUIRE(strand.running_in_this_thread());
 		auto const btc = azmq::async_send(sc, snd_bufs, yield);
-		ASSERT_TRUE(strand.running_in_this_thread());
-		ASSERT_TRUE(btc == 4);
+		REQUIRE(strand.running_in_this_thread());
+		REQUIRE(btc == 4);
 	});
 
 	//receive coroutine task
@@ -924,23 +924,23 @@ TEST_CASE("Async Operation Send/Receive single message, check thread safety", "[
 
 		boost::system::error_code ecc;
 
-		ASSERT_TRUE(strand.running_in_this_thread());
+		REQUIRE(strand.running_in_this_thread());
 		auto const btb1 = azmq::async_receive(sb, boost::asio::buffer(ident), yield[ecc]);
-		ASSERT_TRUE(strand.running_in_this_thread());
-		ASSERT_TRUE(ecc);
-		ASSERT_TRUE(btb1 == 5);
+		REQUIRE(strand.running_in_this_thread());
+		REQUIRE(ecc);
+		REQUIRE(btb1 == 5);
 
 		auto const btb2 = azmq::async_receive(sb, boost::asio::buffer(a), yield[ecc]);
-		ASSERT_TRUE(strand.running_in_this_thread());
-		ASSERT_TRUE(ecc);
-		ASSERT_TRUE(btb2 == 2);
-		ASSERT_TRUE(message_ref(snd_bufs.at(0)) == boost::string_ref(a.data(), 2));
+		REQUIRE(strand.running_in_this_thread());
+		REQUIRE(ecc);
+		REQUIRE(btb2 == 2);
+		REQUIRE(message_ref(snd_bufs.at(0)) == boost::string_ref(a.data(), 2));
 
 		auto const btb3 = azmq::async_receive(sb, boost::asio::buffer(b), yield[ecc]);
-		ASSERT_TRUE(strand.running_in_this_thread());
-		ASSERT_TRUE(ecc);
-		ASSERT_TRUE(btb3 == 2);
-		ASSERT_TRUE(message_ref(snd_bufs.at(1)) == boost::string_ref(b.data(), 2));
+		REQUIRE(strand.running_in_this_thread());
+		REQUIRE(ecc);
+		REQUIRE(btb3 == 2);
+		REQUIRE(message_ref(snd_bufs.at(1)) == boost::string_ref(b.data(), 2));
 	});
 
 	ios.run();

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -18,6 +18,9 @@
 #include <boost/asio/use_future.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/optional.hpp>
+#if BOOST_VERSION >= 107400
+#include <boost/asio/any_io_executor.hpp>
+#endif
 #endif
 
 #include <array>
@@ -896,7 +899,7 @@ TEST_CASE("Async Operation Send/Receive single message, stackful coroutine, one 
 
 TEST_CASE("Async Operation Send/Receive single message, check thread safety", "[socket_ops]") {
 	boost::asio::io_service ios;
-#if BOOST_VERSION > 107700
+#if BOOST_VERSION > 107400
 	boost::asio::strand<boost::asio::any_io_executor> strand{ios.get_executor()};
 #else
 	boost::asio::strand<boost::asio::executor> strand{ios.get_executor()};

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -882,14 +882,19 @@ TEST_CASE("Async Operation Send/Receive single message, stackful coroutine, one 
       auto frame1 = azmq::message{};
       auto const btb1 = azmq::async_receive(sb, frame1, yield);
       REQUIRE(btb1 == 5);
+      REQUIRE(frame1.more());
 
       auto frame2 = azmq::message{};
       auto const btb2 = azmq::async_receive(sb, frame2, yield);
       REQUIRE(btb2 == 2);
+      REQUIRE(frame2.more());
+      REQUIRE(message_ref(snd_bufs.at(0)) == message_ref(frame2));
 
       auto frame3 = azmq::message{};
       auto const btb3 = azmq::async_receive(sb, frame3, yield);
       REQUIRE(btb3 == 2);
+      REQUIRE(!frame3.more());
+      REQUIRE(message_ref(snd_bufs.at(1)) == message_ref(frame3));
 
     });
 

--- a/test/socket_ops/main.cpp
+++ b/test/socket_ops/main.cpp
@@ -2,6 +2,7 @@
 #include <azmq/detail/socket_ops.hpp>
 
 #include <boost/asio/buffer.hpp>
+#include <boost/current_function.hpp>
 
 #include <array>
 #include <chrono>


### PR DESCRIPTION
Added test case and solution for fix #212 . 
Ensure that after the completion handler of the async operation, the same thread is still used.

After the completion handler has been completed dispatch the completion handler through the executor of the handler and using the associated allocator of the handler. The handler is moved since it is pretty safe to say that the `do_complete()` function will be the last function called on the object that uses the handler.

Solution based on https://github.com/chriskohlhoff/asio/blob/master/asio/src/examples/cpp14/operations/callback_wrapper.cpp that implements a custom asio operation to show how this is done. 

The `boost::asio::bind_allocator` was only added in Boost version 1.79 and I am not entirely sure how `bind_allocator` works before Boost version 1.79. Not sure how to handle this. I have left out the `bind_allocator` logic for any boost version < 1.79.