### PR TITLE
fix tests for boost asio>=1.80

### DIFF
--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -839,7 +839,7 @@ TEST_CASE("Async Operation Send/Receive with stackful coroutine", "[socket_ops]"
     //send coroutine task
     boost::asio::spawn(ios, [&](boost::asio::yield_context yield) {
       btc = azmq::async_send(sc, snd_bufs, yield);
-    });
+    }, boost::coroutines::attributes());
 
     //receive coroutine task
     boost::asio::spawn(ios, [&](boost::asio::yield_context yield) {
@@ -854,7 +854,7 @@ TEST_CASE("Async Operation Send/Receive with stackful coroutine", "[socket_ops]"
                                                              }};
 
       btb = azmq::async_receive(sb, rcv_bufs, yield);
-    });
+    }, boost::coroutines::attributes());
 
     ios.run();
     REQUIRE(btb.has_value());
@@ -877,7 +877,7 @@ TEST_CASE("Async Operation Send/Receive single message, stackful coroutine, one 
     boost::asio::spawn(ios, [&](boost::asio::yield_context yield) {
       auto const btc = azmq::async_send(sc, snd_bufs, yield);
       REQUIRE(btc == 4);
-    });
+    }, boost::coroutines::attributes());
 
     //receive coroutine task
     boost::asio::spawn(ios, [&](boost::asio::yield_context yield) {
@@ -898,7 +898,7 @@ TEST_CASE("Async Operation Send/Receive single message, stackful coroutine, one 
       REQUIRE(!frame3.more());
       REQUIRE(message_ref(snd_bufs.at(1)) == message_ref(frame3));
 
-    });
+    }, boost::coroutines::attributes());
 
     ios.run();
 }


### PR DESCRIPTION
The signature of `boost::asio::spawn` has been changed since boost asio 1.80, more details: [Boost Asio Revision History](https://www.boost.org/doc/libs/latest/doc/html/boost_asio/history.html#boost_asio.history.asio_1_24_0___boost_1_80).